### PR TITLE
Add a stub test and enable flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+    - "2.7"
+install:
+    - python setup.py -q install
+    - pip install -q tox
+script:
+    - tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.org/rwood-moz/raptor.svg?branch=master)](https://travis-ci.org/rwood-moz/raptor)
+
 # raptor
 Desktop browser performance framework prototype
 

--- a/raptor/browser.py
+++ b/raptor/browser.py
@@ -33,13 +33,13 @@ def start_browser(browser, browser_bin, profile):
 
     # start the browser (and on startup, the webext starts the test)
     try:
-        pcontext = run_browser(
+        run_browser(
             command_args,
             minidump_dir,
             timeout=timeout
         )
         # framework halts here until browser is shutdown
     except Exception:
-        #self.check_for_crashes(browser_config, minidump_dir,
-        #                       test_config['name'])
+        # self.check_for_crashes(browser_config, minidump_dir,
+        #                        test_config['name'])
         raise

--- a/raptor/browser_preferences.py
+++ b/raptor/browser_preferences.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import absolute_import
 
-import os
 import time
 
 from mozlog import get_proxy_logger

--- a/raptor/cmdline.py
+++ b/raptor/cmdline.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, print_function
 
 import argparse
-import os
 
 from mozlog.commandline import add_logging_group
 

--- a/raptor/control_server.py
+++ b/raptor/control_server.py
@@ -20,16 +20,16 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_GET(self):
         # get handler, received request for test settings from web ext runner
         self.send_response(200)
-        validFiles = ['raptor-firefox-tp7.json', 
+        validFiles = ['raptor-firefox-tp7.json',
                       'raptor-chrome-tp7.json',
-                      'raptor-speedometer.json'];
+                      'raptor-speedometer.json']
         head, tail = os.path.split(self.path)
         if tail in validFiles:
             LOG.info('reading test settings from ' + tail)
             try:
                 with open(tail) as json_settings:
                     self.send_header('Access-Control-Allow-Origin', '*')
-                    self.send_header('Content-type','application/json')
+                    self.send_header('Content-type', 'application/json')
                     self.end_headers()
                     self.wfile.write(json.dumps(json.load(json_settings)))
                     self.wfile.close()

--- a/raptor/profile.py
+++ b/raptor/profile.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import absolute_import
 
-import os
-
 from mozlog import get_proxy_logger
 from mozprofile import Profile
 

--- a/raptor/raptor.py
+++ b/raptor/raptor.py
@@ -6,10 +6,8 @@
 
 from __future__ import absolute_import
 
-import argparse
 import os
 import sys
-import time
 
 from mozlog import commandline, get_default_logger
 
@@ -61,7 +59,7 @@ class Raptor(object):
 
 def main(args=sys.argv[1:]):
     args = parse_args()
-    log = commandline.setup_logging('raptor', args, {'tbpl': sys.stdout})
+    commandline.setup_logging('raptor', args, {'tbpl': sys.stdout})
 
     raptor = Raptor(options=args)
 

--- a/raptor/raptor_process.py
+++ b/raptor/raptor_process.py
@@ -6,7 +6,6 @@
 
 from __future__ import absolute_import
 
-import pprint
 import signal
 import time
 import traceback
@@ -21,8 +20,10 @@ from mozprocess import ProcessHandler
 
 LOG = get_proxy_logger(component='raptor_process')
 
+
 class RaptorError(Exception):
     "Errors found while running the talos harness."
+
 
 class ProcessContext(object):
     """

--- a/raptor/webext.py
+++ b/raptor/webext.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import os
 
 from mozlog import get_proxy_logger
-from mozprofile import AddonManager
 
 LOG = get_proxy_logger(component='webext')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mozcrash==1.0
-mozinfo==0.10
-mozlog==3.7
-mozprofile==0.29
-mozprocess==0.26
+mozcrash
+mozinfo
+mozlog
+mozprofile
+mozprocess
 psutil==5.4.3

--- a/test/test_raptor.py
+++ b/test/test_raptor.py
@@ -1,0 +1,2 @@
+def test_stub():
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,17 @@
 [tox]
-envlist=py27
+envlist=py27,flake8
 
 [testenv]
 deps=
     pytest
 commands=pytest -vv
+
+[testenv:flake8]
+basepython=python2
+skip_install=true
+deps=
+    flake8
+commands=flake8 raptor test
+
+[flake8]
+max-line-length=100

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist=py27
+
+[testenv]
+deps=
+    pytest
+commands=pytest -vv


### PR DESCRIPTION
This just adds an empty test, but sets up all the CI bits. I'll add proper tests as I go for the things I change. In general if something I'm changing is missing test coverage, I'll try to:
1) Add a test that passes before my changes
2) Make my changes and update the test at the same time

We'll need to change the flake8/pytest configuration a bit when this lands in mozilla-central, but this shouldn't be hard and we'll be able to re-use all of the tests we write here.